### PR TITLE
chore: automatizar versión semántica y changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,89 @@
-name: Release
+name: Generate Release & Publish
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Force version bump (optional)'
+        required: false
+        type: choice
+        default: 'auto'
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 jobs:
-  publish:
+  release:
+    name: Build, Publish and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup JDK 21
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate Version and Changelog
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+          default_bump: false
+          custom_release_rules: feat:minor,fix:patch,chore:patch
+
+      - name: Check version bump
+        if: steps.tag_version.outputs.new_version == ''
+        run: |
+          echo "No new version to publish. Exiting."
+          exit 1
+
+      - name: Convert Markdown to HTML for JetBrains (local)
+        id: convert_notes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+          printf "%s" "${{ steps.tag_version.outputs.changelog }}" > CHANGELOG.md
+          pandoc -f gfm -t html CHANGELOG.md -o CHANGELOG.html
+          {
+            echo "html<<EOF"
+            cat CHANGELOG.html
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Java
         uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: '21'
-          distribution: 'temurin'
-          cache: 'gradle'
-      - run: chmod +x gradlew
 
-      - name: Build plugin
-        run: ./gradlew buildPlugin
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
-      - name: Publish Plugin to JetBrains Marketplace
-        run: ./gradlew publishPlugin
+      - name: Build and Test
         env:
-          JETBRAINS_PUBLISH_TOKEN: ${{ secrets.JETBRAINS_PUBLISH_TOKEN }}
-          CHANNEL: ${{
-            contains(github.ref_name, 'alpha') && 'alpha' ||
-            (contains(github.ref_name, 'beta') && 'beta' || 'default')
-            }}
+          RELEASE_VERSION: ${{ steps.tag_version.outputs.new_version }}
+          RELEASE_CHANGELOG: ${{ steps.convert_notes.outputs.html }}
+        run: ./gradlew buildPlugin test
+
+      - name: Publish to JetBrains Marketplace
+        env:
+          JETBRAINS_PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          RELEASE_VERSION: ${{ steps.tag_version.outputs.new_version }}
+          RELEASE_CHANGELOG: ${{ steps.convert_notes.outputs.html }}
+        run: ./gradlew publishPlugin
 
       - name: Create GitHub Release
+        if: steps.tag_version.outputs.new_version != ''
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          body: |
-            🚀 Published plugin version ${{ github.ref_name }}
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_version }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          files: build/distributions/*
         env:
-          GITHUB_TOKEN: ${{ github.token  }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to ZeitBuilder
+
+First off, thank you for considering contributing to ZeitBuilder! It's people like you that make ZeitBuilder such a great tool for the JetBrains community.
+
+## 🌿 Branching Strategy
+
+We use a feature-branching workflow. **Direct pushes to the `master` branch are disabled** or highly discouraged. To contribute:
+
+1. **Fork** the repository (or if you have write access, create a new branch).
+2. Create a branch for your feature or bug fix:
+   - For features: `feat/mi-nueva-funcion`
+   - For bug fixes: `fix/error-al-cargar`
+   - For chores/documentation: `chore/actualizar-readme`
+3. Develop your changes.
+4. **Push** your branch and open a **Pull Request** against the `master` branch.
+5. Our CI workflow will automatically run formatting checks and tests.
+6. Once approved, it will be merged into `master`.
+
+## ✍️ Commit Message Convention
+
+To automate our semantic versioning and release notes (changelog) generation, we strictly follow **[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)**.
+
+Every commit message **must** be formatted as follows:
+
+```
+<type>(<optional scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+The `<type>` must be one of the following:
+
+* **`feat`**: A new feature (correlates with a `MINOR` release).
+* **`fix`**: A bug fix (correlates with a `PATCH` release).
+* **`docs`**: Documentation only changes.
+* **`style`**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
+* **`refactor`**: A code change that neither fixes a bug nor adds a feature.
+* **`perf`**: A code change that improves performance.
+* **`test`**: Adding missing tests or correcting existing tests.
+* **`chore`**: Changes to the build process or auxiliary tools and libraries such as documentation generation.
+
+### Examples
+
+* `feat: añadir nueva interfaz de selección de clase`
+* `fix(ui): resolver NullPointerException al abrir la ventana modal`
+* `docs: actualizar el README con instrucciones de setup`
+* `chore: actualizar librería kotlin a la versión 2.1.0`
+
+### Breaking Changes
+
+If your commit introduces a breaking change, prepend a `!` before the colon or add a `BREAKING CHANGE:` footer. This will trigger a `MAJOR` release.
+**Example**: `feat!: remove support for JetBrains IDE versions prior to 2023.1`
+
+## 🚀 Release Process (Maintainers Only)
+
+The release process is entirely automated through GitHub Actions!
+
+We do **not** publish releases automatically on every merge. Instead, we bundle features and triggers the publication manually:
+
+1. Go to the **Actions** tab in GitHub.
+2. Select **Generate Release & Publish**.
+3. Click **Run workflow** mapping to `master`.
+
+The workflow will automatically:
+1. Examine all conventional commits since the last release.
+2. Calculate the next semantic version (`MAJOR`, `MINOR`, or `PATCH`).
+3. Generate comprehensive Release Notes based on the commit history.
+4. Convert those notes into standard HTML for JetBrains Marketplace.
+5. Compile and publish the plugin.
+6. Create a GitHub Release and a git tag.
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,8 @@ val assertjVersion = "3.27.7"
 val junitVersion = "4.13.2"
 
 group = "com.zeitbuilder"
-version = System.getenv("GITHUB_REF_NAME")?.removePrefix("v") ?: "1.0.0-SNAPSHOT"
+val pluginVersion = System.getenv("RELEASE_VERSION") ?: "1.0.1-SNAPSHOT"
+version = pluginVersion
 
 repositories {
     mavenCentral()
@@ -41,15 +42,10 @@ intellijPlatform {
             sinceBuild = "231"
         }
 
-        changeNotes = """
-            <ul>
-                <li>feat: agregar soporte para generadores de builders extensibles</li>
-                <li>fix: genera automáticamente constructor sin argumentos, excepto cuando existen propiedades final</li>
-                <li>build: actualizar versión de AssertJ a 3.27.7</li>
-                <li>refactor: migrar uso de constantes PsiType obsoletas</li>
-                <li>feat: agregar soporte para generadores de builders de records</li>
-            </ul>
-        """.trimIndent()
+        val rawChangelog = System.getenv("RELEASE_CHANGELOG") ?: "<ul><li>Local build / Snapshot</li></ul>"
+        changeNotes = "<![CDATA[\n$rawChangelog\n]]>"
+        
+        version = pluginVersion
     }
 
 }
@@ -60,8 +56,16 @@ tasks {
         targetCompatibility = "21"
     }
 
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+    }
+
     test {
         useJUnit()
+    }
+
+    signPlugin {
+        // Configuration for signing the plugin
     }
 
     publishPlugin {


### PR DESCRIPTION
This pull request introduces a new `CONTRIBUTING.md` to document contribution guidelines and significantly overhauls the release workflow in `.github/workflows/release.yml`. The release process is now manual (via workflow dispatch), automates semantic versioning and changelog generation based on commit conventions, and improves the build and publishing pipeline for the JetBrains plugin.

**Documentation and Contribution Process:**

* Added a comprehensive `CONTRIBUTING.md` outlining the branching strategy, commit message conventions (using Conventional Commits), and the new release process, including instructions for both contributors and maintainers.

**Release Workflow Improvements:**

* Refactored `.github/workflows/release.yml` to use a manual workflow dispatch with version bump options, replacing the previous tag-push trigger. This enables maintainers to control release timing and versioning.
* Integrated `mathieudutour/github-tag-action` to automatically determine the next semantic version and generate changelogs based on commit history, enforcing the Conventional Commits standard.
* Added a step to convert the generated changelog from Markdown to HTML using `pandoc`, ensuring compatibility with JetBrains Marketplace requirements.
* Improved build and publish steps: switched Java distribution, separated Gradle setup, and passed version/changelog as environment variables for publishing.
* Updated GitHub Release creation to use the new version and changelog, and to upload build artifacts from the new workflow.